### PR TITLE
Ошибка в переводе

### DIFF
--- a/book/02-git-basics/sections/aliases.asc
+++ b/book/02-git-basics/sections/aliases.asc
@@ -34,7 +34,7 @@ $ git config --global alias.unstage 'reset HEAD --'
 [source,console]
 ----
 $ git unstage fileA
-$ git reset HEAD fileA
+$ git reset HEAD -- fileA
 ----
 
 Такой вариант кажется немного более понятным.


### PR DESCRIPTION
Ошибка в команде git reset HEAD -- при переводе [оригинала](https://github.com/progit/progit2/blob/master/book/02-git-basics/sections/aliases.asc) на русский.