### PR TITLE
Fix /opt /srv path inconsistency

### DIFF
--- a/book/04-git-server/sections/setting-up-server.asc
+++ b/book/04-git-server/sections/setting-up-server.asc
@@ -68,7 +68,7 @@ $ cd myproject
 $ git init
 $ git add .
 $ git commit -m 'initial commit'
-$ git remote add origin git@gitserver:/opt/git/project.git
+$ git remote add origin git@gitserver:/srv/git/project.git
 $ git push origin master
 ----
 


### PR DESCRIPTION
Align path to `/srv/git/project.git` to make example more consistent